### PR TITLE
Return ApiContext

### DIFF
--- a/PaymentFactory.php
+++ b/PaymentFactory.php
@@ -79,6 +79,7 @@ class PaymentFactory implements PaymentFactoryInterface
 
                 $credential = new OAuthTokenCredential($config['client_id'], $config['client_secret']);
                 $config['payum.api'] = new ApiContext($credential);
+                return $config['payum.api'];
             };
         }
 


### PR DESCRIPTION
Core/PaymentFactory expects the closure to return the api context.

``` php
$payment->addApi(call_user_func_array($value, array($config)), $prepend);
```

Currently it returns nothing which causes the exception -

``` php
Cannot find right api supported by Payum\Paypal\Rest\Action\CaptureAction
```
